### PR TITLE
GCP Service Account Credential as docker env variable for cloud scanner

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -60,6 +60,9 @@ services:
       # AZURE_CLIENT_SECRET: ""
       # AZURE_SUBSCRIPTION_ID: ""
       
+      # Provide base64 encoded Service Account Keys for GCP Scanner  
+      # GCP_SERVICE_ACCOUNT_CREDENTIAL: ""
+      
       DEPLOYMENT_MODE: "docker"
       HOME_DIR: "/home/deepfence"
       DF_INSTALL_DIR: "/data/home/deepfence"
@@ -74,3 +77,4 @@ services:
 volumes:
   cloud_scanner_data:
     driver: local
+

--- a/helm-chart/deepfence-cloud-scanner/values.yaml
+++ b/helm-chart/deepfence-cloud-scanner/values.yaml
@@ -96,6 +96,7 @@ env_vars: {}
   # AZURE_CLIENT_ID :
   # AZURE_CLIENT_SECRET:
   # AZURE_SUBSCRIPTION_ID: 
+  # GCP_SERVICE_ACCOUNT_CREDENTIAL:
 
 imagePullSecrets: []
 nameOverride: ""

--- a/service/service.go
+++ b/service/service.go
@@ -243,7 +243,7 @@ func (c *ComplianceScanService) fetchGCPProjects() ([]util.MonitoredAccount, err
 
 func saveGCPCredentialsToFile(credentials string) (string, error) {
     
-    configDir := "/home/deepfence/.config/gcloud/"
+    configDir := util.HomeDirectory+"/.config/gcloud/"
     credentialFilePath := configDir + "application_default_credentials.json"
 
     // Check if the directory exists, create it if not

--- a/util/type.go
+++ b/util/type.go
@@ -70,6 +70,7 @@ type Config struct {
 	ScanInactiveThreshold    int      `envconfig:"SCAN_INACTIVE_THRESHOLD" default:"21600" json:"scan_inactive_threshold"`
 	CloudScannerPolicy       string   `envconfig:"CLOUD_SCANNER_POLICY" json:"cloud_scanner_policy"`
 	DeploymentMode           string   `envconfig:"DEPLOYMENT_MODE" json:"deployment_mode"`
+	GCPCredentials string `envconfig:"GCP_SERVICE_ACCOUNT_CREDENTIAL" json:"gcp_service_account_credential"`
 
 	CloudMetadata                cloudmetadata.CloudMetadata `ignored:"true" json:"cloud_metadata"`
 	NodeID                       string                      `ignored:"true" json:"-"`
@@ -200,3 +201,4 @@ func init() {
 		SteampipeInstallDirectory = "/home/deepfence/.steampipe"
 	}
 }
+


### PR DESCRIPTION
[+] Added support for passing in Service Account Key Credential content as base64 encoded env variable.
[+] Does this break anything : No, All existing functionality works.


```
data "google_client_config" "current" {}

resource "google_project_service" "cloud_resource_manager" {
  project = ""
  service = "cloudresourcemanager.googleapis.com"
  disable_on_destroy = false
}

module "cloud_scanner_example_multiple_project" {
  source                   = "deepfence/cloud-scanner/gcp//examples/gce-vm"
  version                  = "0.8.0"
  # gcp service account name
  name                     = "deepfence-cloud-scanner"
  # project_id example: dev1-123456
  project_id               = ""
  # org mode for multiple projects
  isOrganizationDeployment = true
}

resource "google_service_account_key" "cloud_scanner_key" {
  service_account_id = module.cloud_scanner_example_multiple_project.service_account_email
}

output "service_account_email" {
  value = module.cloud_scanner_example_multiple_project.service_account_email
}

output "service_account_key" {
  value     = google_service_account_key.cloud_scanner_key.private_key
  sensitive = true
}

```