### PR TITLE
EKS cluster IAM role - support cluster in different account from where CloudFormation is deployed

### DIFF
--- a/cloudformation/self-hosted/eks-iam-roles/organization-eks-iam-role/deepfence-cloud-scanner-organization-iam-role.template
+++ b/cloudformation/self-hosted/eks-iam-roles/organization-eks-iam-role/deepfence-cloud-scanner-organization-iam-role.template
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: '2010-09-09'
-Description:  Deepfence Cloud Scanner IAM role for Organization Deployment
+Description: Deepfence Cloud Scanner IAM role for Organization Deployment
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -33,21 +33,24 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       Path: /
-      RoleName: !Ref ParentStackName
-      AssumeRolePolicyDocument: !Sub |
-        {
-          "Version": "2012-10-17",
-          "Statement": [
-            {
-              "Effect": "Allow",
-              "Principal": {
-                "AWS": "arn:aws:iam::${CloudScannerAccountId}:role/${ParentStackName}"
-              },
-              "Action": "sts:AssumeRole"
-            }
-          ]
-        }
+      RoleName: !Join
+      - ''
+      - - !Ref ParentStackName
+      AssumeRolePolicyDocument: !Join
+      - ''
+      - - '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":["arn:aws:iam::'
+        - !Ref CloudScannerAccountId
+        - ':role/'
+        - !Join
+          - ''
+          - - !Ref ParentStackName
+            - EKSRole
+        - '"]},"Action":"sts:AssumeRole"}]}'
       MaxSessionDuration: 3600
       ManagedPolicyArns:
       - !Ref TaskIAMRole
-      Description: Provide AssumeRole permission to Deepfence Managed Cloud Scanner
+      Tags:
+      - Key: Name
+        Value: !Join
+        - ''
+        - - !Ref ParentStackName

--- a/cloudformation/self-hosted/eks-iam-roles/organization-eks-iam-role/deepfence-cloud-scanner-organization-stackset-iam-role.template
+++ b/cloudformation/self-hosted/eks-iam-roles/organization-eks-iam-role/deepfence-cloud-scanner-organization-stackset-iam-role.template
@@ -8,6 +8,11 @@ Metadata:
       Parameters:
       - TaskIAMRole
       - OrganizationalUnitIds
+      - EKSClusterName
+      - EKSClusterOIDCURL
+      - K8sNamespace
+      - K8sServiceAccountName
+      - TargetAWSAccountID
     ParameterLabels:
       EKSClusterName:
         default: EKS cluster where cloud-scanner will be deployed
@@ -21,6 +26,8 @@ Metadata:
         default: If SecurityAudit role is chosen, cloud scanner may not find configuration issues in some of the AWS resources like WAF. Also updates will happen only once every day.
       OrganizationalUnitIds:
         default: List of Organizational Unit IDs to deploy the StackSet (IAM Roles)
+      TargetAWSAccountID:
+        default: Target Member AWS Account ID
 Parameters:
   EKSClusterName:
     Type: String
@@ -43,53 +50,66 @@ Parameters:
   OrganizationalUnitIds:
     Type: List<String>
     Description: Organizational Unit IDs
+  TargetAWSAccountID:
+    Type: String
+    Description: AWS account ID of EKS cluster
 Resources:
-  ReadOnlyRole:
-    Type: AWS::IAM::Role
+  TargetAccountIAMRoleStackSetComplete:
+    Type: AWS::CloudFormation::WaitConditionHandle
+  TargetAccountIAMRoleStackSetCompleteWait:
+    Type: AWS::CloudFormation::WaitCondition
+    DependsOn: TargetAccountIAMRoleStackSet
     Properties:
-      Path: /
-      RoleName: !Ref 'AWS::StackName'
-      AssumeRolePolicyDocument: !Sub |
-        {
-          "Version": "2012-10-17",
-          "Statement": [
-            {
-              "Effect": "Allow",
-              "Principal": {
-                "Federated": "arn:aws:iam::${AWS::AccountId}:oidc-provider/${EKSClusterOIDCURL}"
-              },
-              "Action": "sts:AssumeRoleWithWebIdentity",
-              "Condition": {
-                "StringEquals": {
-                  "${EKSClusterOIDCURL}:sub": "system:serviceaccount:${K8sNamespace}:${K8sServiceAccountName}",
-                  "${EKSClusterOIDCURL}:aud": "sts.amazonaws.com"
-                }
-              }
-            }
-          ]
-        }
-      MaxSessionDuration: 3600
-      ManagedPolicyArns:
-      - !Ref TaskIAMRole
-      - arn:aws:iam::aws:policy/AWSOrganizationsReadOnlyAccess
-      Policies:
-      - PolicyName: !Sub "${AWS::StackName}-AllowAssumeRoleInChildAccounts"
-        PolicyDocument: !Sub |
-          {
-            "Version": "2012-10-17",
-            "Statement": [
-              {
-                "Effect": "Allow",
-                "Resource": ["arn:aws:iam::*:role/${AWS::StackName}"],
-                "Action": "sts:AssumeRole"
-              }
-            ]
-          }
-      Description: Provide AssumeRole permission to Deepfence Cloud Scanner on child accounts
-  StackSet:
+      Handle: !Ref TargetAccountIAMRoleStackSetComplete
+      Timeout: '180'
+  TargetAccountIAMRoleStackSet:
     Type: AWS::CloudFormation::StackSet
     Properties:
-      Description: 'Deploy IAM role across accounts in the Organization to provide permission to Cloud Scanner'
+      AutoDeployment:
+        Enabled: false
+      Capabilities:
+      - CAPABILITY_NAMED_IAM
+      Description: Deployment of IAM Role for Cloud Scanner in the AWS account of EKS cluster
+      ManagedExecution:
+        Active: true
+      OperationPreferences:
+        FailureToleranceCount: 0
+        MaxConcurrentCount: 1
+        RegionConcurrencyType: SEQUENTIAL
+        RegionOrder:
+        - !Ref AWS::Region
+      Parameters:
+      - ParameterKey: ParentStackName
+        ParameterValue: !Ref AWS::StackName
+      - ParameterKey: TaskIAMRole
+        ParameterValue: !Ref TaskIAMRole
+      - ParameterKey: EKSClusterOIDCURL
+        ParameterValue: !Ref EKSClusterOIDCURL
+      - ParameterKey: K8sNamespace
+        ParameterValue: !Ref K8sNamespace
+      - ParameterKey: K8sServiceAccountName
+        ParameterValue: !Ref K8sServiceAccountName
+      - ParameterKey: SuccessSignalURL
+        ParameterValue: !Ref TargetAccountIAMRoleStackSetComplete
+      PermissionModel: SERVICE_MANAGED
+      StackInstancesGroup:
+      - DeploymentTargets:
+          AccountFilterType: INTERSECTION
+          OrganizationalUnitIds: !Ref OrganizationalUnitIds
+          Accounts:
+          - !Ref TargetAWSAccountID
+        Regions:
+        - !Ref AWS::Region
+      StackSetName: !Join
+      - ''
+      - - !Ref AWS::StackName
+        - OrgDeployment
+      TemplateURL: https://deepfence-public.s3.amazonaws.com/cloud-scanner/self-hosted/eks-iam-roles/organization-eks-iam-role/deepfence-cloud-scanner-organization-target-account-iam-role.template
+  MemberAccountsIAMRoleStackSet:
+    Type: AWS::CloudFormation::StackSet
+    DependsOn: TargetAccountIAMRoleStackSetCompleteWait
+    Properties:
+      Description: Deploy IAM role across accounts in the Organization to provide permission to Cloud Scanner
       AutoDeployment:
         Enabled: true
         RetainStacksOnAccountRemoval: false
@@ -105,24 +125,60 @@ Resources:
       - ParameterKey: TaskIAMRole
         ParameterValue: !Ref TaskIAMRole
       - ParameterKey: ParentStackName
-        ParameterValue: !Ref 'AWS::StackName'
+        ParameterValue: !Ref AWS::StackName
       - ParameterKey: CloudScannerAccountId
-        ParameterValue: !Ref 'AWS::AccountId'
+        ParameterValue: !Ref TargetAWSAccountID
       PermissionModel: SERVICE_MANAGED
       StackInstancesGroup:
       - DeploymentTargets:
-          AccountFilterType: NONE
+          AccountFilterType: DIFFERENCE
           OrganizationalUnitIds: !Ref OrganizationalUnitIds
+          Accounts:
+          - !Ref AWS::AccountId
         Regions:
         - !Ref AWS::Region
       StackSetName: !Ref AWS::StackName
       TemplateURL: https://deepfence-public.s3.amazonaws.com/cloud-scanner/self-hosted/eks-iam-roles/organization-eks-iam-role/deepfence-cloud-scanner-organization-iam-role.template
+  OrganizationAccountIAMRole:
+    Type: AWS::IAM::Role
+    DependsOn: TargetAccountIAMRoleStackSetCompleteWait
+    Properties:
+      Path: /
+      RoleName: !Join
+      - ''
+      - - !Ref AWS::StackName
+      AssumeRolePolicyDocument: !Join
+      - ''
+      - - '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":["arn:aws:iam::'
+        - !Ref TargetAWSAccountID
+        - ':role/'
+        - !Join
+          - ''
+          - - !Ref AWS::StackName
+            - EKSRole
+        - '"]},"Action":"sts:AssumeRole"}]}'
+      MaxSessionDuration: 3600
+      ManagedPolicyArns:
+      - !Ref TaskIAMRole
+      - arn:aws:iam::aws:policy/AWSOrganizationsReadOnlyAccess
+      Tags:
+      - Key: Name
+        Value: !Join
+        - ''
+        - - !Ref AWS::StackName
 Outputs:
   EKSClusterName:
+    Description: EKS cluster name, for your reference
     Value: !Ref EKSClusterName
   K8sNamespace:
+    Description: Deploy the cloud scanner helm chart in this namespace
     Value: !Ref K8sNamespace
   K8sServiceAccountName:
+    Description: Set service account name in helm chart 'serviceAccount.name'
     Value: !Ref K8sServiceAccountName
-  ReadOnlyRoleIAMRoleARN:
-    Value: !GetAtt ReadOnlyRole.Arn
+  ServiceAccountRoleARN:
+    Description: Set the IAM role ARN in helm chart 'serviceAccount.annotations'
+    Value: !GetAtt TargetAccountIAMRoleStackSetCompleteWait.Data
+  MemberAccountsRoleName:
+    Description: Set the IAM role name in helm chart 'cloudAccount.roleName'
+    Value: !Ref AWS::StackName

--- a/cloudformation/self-hosted/eks-iam-roles/organization-eks-iam-role/deepfence-cloud-scanner-organization-target-account-iam-role.template
+++ b/cloudformation/self-hosted/eks-iam-roles/organization-eks-iam-role/deepfence-cloud-scanner-organization-target-account-iam-role.template
@@ -1,0 +1,161 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Deepfence Cloud Scanner IAM role for Organization Deployment
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+    - Label:
+        default: Configuration
+      Parameters:
+      - TaskIAMRole
+      - ParentStackName
+      - EKSClusterOIDCURL
+      - K8sNamespace
+      - K8sServiceAccountName
+      - SuccessSignalURL
+    ParameterLabels:
+      TaskIAMRole:
+        default: If SecurityAudit role is chosen, cloud scanner may not find
+          configuration issues in some of the AWS resources like WAF. Also
+          updates will happen only once every day.
+      ParentStackName:
+        default: Parent Stack Name
+      EKSClusterOIDCURL:
+        default: The OpenID Connect URL without protocol (the "https://" prefix)
+      K8sNamespace:
+        default: k8s namespace for the cloud-scanner
+      K8sServiceAccountName:
+        default: k8s service account for the cloud-scanner
+      SuccessSignalURL:
+        default: URL to send notification when IAM role is created
+Parameters:
+  TaskIAMRole:
+    Type: String
+    Description: Task Role
+    Default: arn:aws:iam::aws:policy/SecurityAudit
+    AllowedValues:
+    - arn:aws:iam::aws:policy/SecurityAudit
+    - arn:aws:iam::aws:policy/ReadOnlyAccess
+  ParentStackName:
+    Type: String
+  EKSClusterOIDCURL:
+    Type: String
+    Description: The OpenID Connect URL without protocol (the "https://" prefix)
+  K8sNamespace:
+    Type: String
+    Default: deepfence
+  K8sServiceAccountName:
+    Type: String
+    Default: deepfence-cloud-scanner
+  SuccessSignalURL:
+    Type: String
+Resources:
+  TargetAccountIAMRole:
+    Type: AWS::IAM::Role
+    Properties:
+      Path: /
+      RoleName: !Join
+      - ''
+      - - !Ref ParentStackName
+        - '-EKSRole'
+      AssumeRolePolicyDocument: !Sub |
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "Federated": "arn:aws:iam::${AWS::AccountId}:oidc-provider/${EKSClusterOIDCURL}"
+              },
+              "Action": "sts:AssumeRoleWithWebIdentity",
+              "Condition": {
+                "StringEquals": {
+                  "${EKSClusterOIDCURL}:sub": "system:serviceaccount:${K8sNamespace}:${K8sServiceAccountName}",
+                  "${EKSClusterOIDCURL}:aud": "sts.amazonaws.com"
+                }
+              }
+            }
+          ]
+        }
+      MaxSessionDuration: 3600
+      ManagedPolicyArns:
+      - !Ref TaskIAMRole
+      Policies:
+      - PolicyName: !Join
+        - ''
+        - - !Ref ParentStackName
+          - '-AllowAssumeRoleInChildAccounts'
+        PolicyDocument: !Join
+        - ''
+        - - '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Resource":["arn:aws:iam::*:role/'
+          - !Ref ParentStackName
+          - '"],"Action":"sts:AssumeRole"}]}'
+      Description: Provide AssumeRole permission to Deepfence Cloud Scanner on child
+        accounts
+      Tags:
+      - Key: Name
+        Value: !Join
+        - ''
+        - - !Ref ParentStackName
+          - EKSRole
+  SuccessSignalFunctionResponse:
+    Type: Custom::SuccessSignalFunctionResponse
+    Properties:
+      ServiceToken: !GetAtt SuccessSignalFunction.Arn
+  SuccessSignalFunction:
+    Type: AWS::Lambda::Function
+    DependsOn: TargetAccountIAMRole
+    Properties:
+      Description: Signal to the SuccessSignalURL from parent Stack on deploying IAM role
+      Environment:
+        Variables:
+          SuccessSignalURL: !Ref SuccessSignalURL
+          TargetAccountIAMRoleARN: !GetAtt TargetAccountIAMRole.Arn
+      Code:
+        ZipFile: |
+          import json
+          from urllib import request
+          import os
+          import cfnresponse
+          def send_success(event, context):
+              success_signal_url = os.getenv('SuccessSignalURL')
+              req = request.Request(success_signal_url, method="PUT")
+              req.add_header('Content-Type', 'application/json')
+              data = {
+                "Status" : "SUCCESS",
+                "Reason" : "Complete",
+                "UniqueId" : "roleARN",
+                "Data" : os.getenv('TargetAccountIAMRoleARN')
+              }
+              data = json.dumps(data)
+              data = data.encode()
+              r = request.urlopen(req, data=data)
+              # content = r.read()
+              cfnresponse.send(event, context, cfnresponse.SUCCESS, {"response": "status code: {0}".format(r.getcode())})
+      Handler: index.send_success
+      Role: !GetAtt LambdaExecutionRole.Arn
+      Runtime: python3.12
+      Timeout: 60
+  LambdaExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument: '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":["lambda.amazonaws.com"]},"Action":["sts:AssumeRole"]}]}'
+      Path: /
+      Policies:
+      - PolicyName: writelog
+        PolicyDocument: '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["logs:CreateLogGroup","logs:CreateLogStream","logs:PutLogEvents"],"Resource":"arn:aws:logs:*:*:*"}]}'
+Outputs:
+  K8sNamespace:
+    Description: Deploy the cloud scanner helm chart in this namespace
+    Value: !Ref K8sNamespace
+  K8sServiceAccountName:
+    Description: Set service account name in helm chart 'serviceAccount.name'
+    Value: !Ref K8sServiceAccountName
+  ServiceAccountRoleARN:
+    Description: Set the IAM role ARN in helm chart 'serviceAccount.annotations'
+    Value: !GetAtt TargetAccountIAMRole.Arn
+  SuccessSignalFunctionResponse:
+    Description: Status of signalling success on presigned URL from parent stack
+    Value: !GetAtt SuccessSignalFunctionResponse.response
+  MemberAccountsRoleName:
+    Description: Set the IAM role name in helm chart 'cloudAccount.roleName'
+    Value: !Ref ParentStackName

--- a/service/service.go
+++ b/service/service.go
@@ -100,7 +100,7 @@ func (c *ComplianceScanService) GetOrganizationAccounts() []util.MonitoredAccoun
 
 func (c *ComplianceScanService) fetchAWSOrganizationAccountIDs() ([]util.AccountsToRefresh, error) {
 	ctx := context.Background()
-	cfg, err := util.GetAWSCredentialsConfig(ctx, c.config.AccountID, c.config.CloudMetadata.Region, c.config, false)
+	cfg, err := util.GetAWSCredentialsConfig(ctx, c.config.OrganizationID, c.config.CloudMetadata.Region, c.config, false)
 	if err != nil {
 		return nil, err
 	}
@@ -287,6 +287,17 @@ func (c *ComplianceScanService) RunRegisterServices() error {
 	switch c.config.CloudProvider {
 	case util.CloudProviderAWS:
 		if c.config.IsOrganizationDeployment {
+			// Set organization account in credentials initially
+			c.organizationAccountIDsLock.Lock()
+			c.organizationAccountIDs = []util.MonitoredAccount{
+				{
+					AccountID: c.config.OrganizationID,
+					NodeID:    util.GetNodeID(c.config.CloudProvider, c.config.OrganizationID),
+				},
+			}
+			c.organizationAccountIDsLock.Unlock()
+			processAwsCredentials(c)
+
 			_, err = c.fetchAWSOrganizationAccountIDs()
 			if err != nil {
 				log.Error().Msg(err.Error())


### PR DESCRIPTION
Organization level CloudFormation can be deployed only in Organization account.
This change supports k8s cluster (to deploy cloud scanner) in a member account.