### PR TITLE
Dynamic Unmarshal of Steampipe query output to  Struct Type 

### DIFF
--- a/cloud_resource_changes/cloud_resource_changes_aws/cloudtrail.go
+++ b/cloud_resource_changes/cloud_resource_changes_aws/cloudtrail.go
@@ -98,11 +98,23 @@ func (c *CloudResourceChangesAWS) getS3Region(s3BucketName, accountID string) st
 		log.Error().Msgf("Error while obtaining s3 bucket region for cloudtrail: %v", stdErr)
 		log.Error().Msgf(string(stdOut))
 	}
-	var s3BucketObjMapList []S3Details
-	if err := json.Unmarshal(stdOut, &s3BucketObjMapList); err != nil {
-		log.Error().Msgf("Error unmarshaling s3 bucket region: %v \n Steampipe Output: %s",
+
+	var steampipeQueryResponse SteampipeQueryResponse
+	if err := json.Unmarshal(stdOut, &steampipeQueryResponse); err != nil {
+		log.Error().Msgf("Error unmarshaling steampipe query details: %v \n Steampipe Output: %s",
 			err, string(stdOut))
+		return s3Region
 	}
+
+	var s3BucketObjMapList, err = ConvertRows[S3Details](steampipeQueryResponse.Rows)
+	if err != nil {
+		log.Error().Msgf("Error converting steampipe query details to S3Details: %v \n Steampipe Output: %s",
+			err, string(stdOut))
+		return s3Region
+	}
+
+	log.Debug().Msgf("s3BucketObjMapList: %+v", s3BucketObjMapList)
+
 	if len(s3BucketObjMapList) == 0 {
 		log.Error().Msgf("Unable to get s3 bucket region, defaulting to us-east-1")
 	} else {
@@ -121,11 +133,23 @@ func getOrgId(accountId string) string {
 		log.Error().Msgf(string(stdOut))
 		return orgId
 	}
-	var orgIdObjMapList []AccountDetails
-	if err := json.Unmarshal(stdOut, &orgIdObjMapList); err != nil {
-		log.Error().Msgf("Error unmarshaling org id: %v \n Steampipe Output: %s", err, string(stdOut))
+
+	var steampipeQueryResponse SteampipeQueryResponse
+	if err := json.Unmarshal(stdOut, &steampipeQueryResponse); err != nil {
+		log.Error().Msgf("Error unmarshaling steampipe query details: %v \n Steampipe Output: %s",
+			err, string(stdOut))
 		return orgId
 	}
+
+	var orgIdObjMapList, err = ConvertRows[AccountDetails](steampipeQueryResponse.Rows)
+	if err != nil {
+		log.Error().Msgf("Error converting steampipe query details to AccountDetails: %v \n Steampipe Output: %s",
+			err, string(stdOut))
+		return orgId
+	}
+
+	log.Debug().Msgf("orgIdObjMapList: %+v", orgIdObjMapList)
+
 	if len(orgIdObjMapList) > 0 {
 		orgId = orgIdObjMapList[0].OrgId
 	}

--- a/cloud_resource_changes/cloud_resource_changes_aws/util.go
+++ b/cloud_resource_changes/cloud_resource_changes_aws/util.go
@@ -54,7 +54,7 @@ func getCloudTrailTrails(config util.Config) []CloudTrailTrail {
 		query = "steampipe query --output json \"select * from aws_all.aws_cloudtrail_trail where is_multi_region_trail = true " + isOrganizationTrail + " and arn in ('" + strings.Join(config.CloudAuditLogsIDs, "', '") + "')\""
 	}
 
-	log.Debug().Msgf("(getCloudTrailTrails) Query: %s", query)
+	log.Debug().Msgf("Steampipe Query: %s", query)
 
 	cmd := exec.Command("bash", "-c", query)
 	stdOut, stdErr := cmd.CombinedOutput()

--- a/cloud_resource_changes/cloud_resource_changes_aws/util_test.go
+++ b/cloud_resource_changes/cloud_resource_changes_aws/util_test.go
@@ -1,0 +1,76 @@
+package cloud_resource_changes_aws
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestConvertRows(t *testing.T) {
+
+	jsonData := []byte(`
+	{
+		"columns": [
+			{
+				"name": "organization_id",
+				"data_type": "text"
+			}
+		],
+		"rows": [
+			{
+				"organization_id": "o-gmktzqiafl"
+			}
+		]
+	}`)
+
+	var steampipeQueryResponse SteampipeQueryResponse
+	if err := json.Unmarshal(jsonData, &steampipeQueryResponse); err != nil {
+		fmt.Println("Error unmarshalling JSON:", err)
+		return
+	}
+
+	accountDetails, err := ConvertRows[AccountDetails](steampipeQueryResponse.Rows)
+	if err != nil {
+		fmt.Println("Error converting rows to AccountDetails:", err)
+		return
+	}
+
+	fmt.Printf("AccountDetails: %+v\n", accountDetails)
+
+	assert.NoError(t, err, "Error converting rows to AccountDetails")
+
+	assert.Len(t, accountDetails, 1, "Expected one AccountDetail")
+	assert.Equal(t, "o-gmktzqiafl", accountDetails[0].OrgId, "Expected OrgId to be o-gmktzqiafl")
+
+	jsonData2 := []byte(`
+	{
+		"columns": [
+			{
+				"name": "region",
+				"data_type": "text"
+			}
+		],
+		"rows": [
+			{
+				"region": "us-west-2"
+			}
+		]
+	}`)
+
+	if err := json.Unmarshal(jsonData2, &steampipeQueryResponse); err != nil {
+		fmt.Println("Error unmarshalling JSON:", err)
+		return
+	}
+
+	s3Details, err := ConvertRows[S3Details](steampipeQueryResponse.Rows)
+	if err != nil {
+		fmt.Println("Error converting rows to S3Details:", err)
+		return
+	}
+
+	fmt.Printf("S3Details: %+v\n", s3Details)
+
+	assert.Len(t, s3Details, 1, "Expected one S3Detail")
+	assert.Equal(t, "us-west-2", s3Details[0].Region, "Expected region to be us-west-2")
+}


### PR DESCRIPTION
The current version 2.4.0 of the cloud scanner does not handle correctly the unmarshalling of AccountDetails and S3Details for the CloudTrail monitoring.

The logs show the following errors

```
Wed, 23 Oct 2024 06:48:21 +0000 ERR cloud_resource_changes_aws/cloudtrail.go:126 Error unmarshaling org id: json: cannot unmarshal object into Go value of type []cloud_resource_changes_aws.AccountDetails
 Steampipe Output: {                                                                                                                                                 "rows": [
  {
   "organization_id": "o-xxxxx"
  }
 ]
}

Wed, 23 Oct 2024 06:48:23 +0000 ERR cloud_resource_changes_aws/cloudtrail.go:103 Error unmarshaling s3 bucket region: json: cannot unmarshal object into Go value of
 type []cloud_resource_changes_aws.S3Details
 Steampipe Output: {
 "rows": [
  {
   "region": "us-west-2"
  }
 ]
}

Wed, 23 Oct 2024 06:48:23 +0000 ERR cloud_resource_changes_aws/cloudtrail.go:107 Unable to get s3 bucket region, defaulting to us-east-1
Wed, 23 Oct 2024 06:48:23 +0000 ERR cloud_resource_changes_aws/cloudtrail.go:198 error listing objects in s3 bucket aws-cloudtrail-logs-xxxx-xxxx error=
"operation error S3: ListObjectsV2, https response error StatusCode: 301, RequestID: J8YG8ZCBH2V9GV27, HostID: BgrCW9lfJGtzoTOZo9Q97yHoIJKIPctNuHsI3N61Cxn4nNvOSLJuZ
CkR1uDDYaKRYF3G7MxtWOY=, api error PermanentRedirect: The bucket you are attempting to access must be addressed using the specified endpoint. Please send all future
 requests to this endpoint."

Mon, 21 Oct 2024 22:48:20 +0000 INF cloud_resource_changes_aws/cloudtrail.go:56 Following CloudTrail Trails are monitored for events every 30 minutes
to update the cloud resources in the management console
Mon, 21 Oct 2024 22:48:20 +0000 INF cloud_resource_changes_aws/cloudtrail.go:58 1. arn:aws:cloudtrail:us-west-2:xxx:trail/xxxx-organization
-trail (Region: us-west-1)
Mon, 21 Oct 2024 23:18:37 +0000 ERR cloud_resource_changes_aws/cloudtrail.go:126 Error unmarshaling org id: json: cannot unmarshal object into Go valu
e of type []cloud_resource_changes_aws.AccountDetails
Mon, 21 Oct 2024 23:19:08 +0000 ERR cloud_resource_changes_aws/cloudtrail.go:103 Error unmarshaling s3 bucket region: json: cannot unmarshal object in
to Go value of type []cloud_resource_changes_aws.S3Details
Mon, 21 Oct 2024 23:19:08 +0000 ERR cloud_resource_changes_aws/cloudtrail.go:107 Unable to get s3 bucket region, defaulting to us-east-1
Mon, 21 Oct 2024 23:19:08 +0000 ERR cloud_resource_changes_aws/cloudtrail.go:198 error listing objects in s3 bucket aws-cloudtrail-logs-xxxx-xxxxx error="operation error S3: ListObjectsV2, https response error StatusCode: 301, RequestID: BJFG2QV3N2VC19DR, HostID: Ds69s3TMH7cRNJkhV5AixjXmBr/0+Vzs
K/f8UBeyPxtyj1CZ8O1Cjset7zLmC1TaxolOEfAXlm8=, api error PermanentRedirect: The bucket you are attempting to access must be addressed using the specified endpoint. Please send all future requests to this endpoint."

Mon, 21 Oct 2024 23:19:12 +0000 DBG cloud_resource_changes_aws/cloudtrail.go:88 Resources types to update: map[]
```

This PR contains the code to support a dynamic unmarshalling for these resources (among the others).

Unit Test with the happy path has been added for verification purpose.

After the fix, this is what is shown in the logs (with debug mode on)

```
Thu, 24 Oct 2024 21:15:20 +0000 INF query_resource/query_service.go:119 Checking cloud audit logs for events
Thu, 24 Oct 2024 21:15:38 +0000 DBG cloud_resource_changes_aws/cloudtrail.go:168 orgIdObjMapList: [{OrgId:o-xxxx}]
Thu, 24 Oct 2024 21:15:39 +0000 DBG cloud_resource_changes_aws/cloudtrail.go:122 s3BucketObjMapList: [{Region:us-west-2}]
```